### PR TITLE
Reviewers optional: Include upgrading clearwater-infrastructre at the start of upgrade

### DIFF
--- a/docs/Upgrading_a_Clearwater_deployment.md
+++ b/docs/Upgrading_a_Clearwater_deployment.md
@@ -21,7 +21,7 @@ uninterrupted service, see "Seamless Upgrade" below.
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install), run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgradee` on each node.
+If you installed your system using the [Manual Install Instructions](Manual_Install), run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node.
 
 ### Chef Install
 

--- a/docs/Upgrading_a_Clearwater_deployment.md
+++ b/docs/Upgrading_a_Clearwater_deployment.md
@@ -21,14 +21,14 @@ uninterrupted service, see "Seamless Upgrade" below.
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install), simply run `sudo clearwater-upgrade` on each node.
+If you installed your system using the [Manual Install Instructions](Manual_Install), run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure` and `sudo clearwater-upgrade` in that order on each node.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo chef-client` followed by `sudo clearwater-upgrade` on each node.
+* Run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure`, `sudo chef-client` and `sudo clearwater-upgrade` in that order on each node.
 
 ## Seamless Upgrade
 
@@ -55,12 +55,11 @@ Bonos, and one Ellis, you should upgrade them in the following order:
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install)
-run `sudo clearwater-upgrade` on each node in the order described above.
+If you installed your system using the [Manual Install Instructions](Manual_Install) run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure` and `sudo clearwater-upgrade` in that order on each node in the order described above.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo chef-client` followed by `sudo clearwater-upgrade` on each node in the order described above.
+* Run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure`, `sudo chef-client` and `sudo clearwater-upgrade` in that order on each node in the order described above.

--- a/docs/Upgrading_a_Clearwater_deployment.md
+++ b/docs/Upgrading_a_Clearwater_deployment.md
@@ -21,14 +21,14 @@ uninterrupted service, see "Seamless Upgrade" below.
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install), run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure` and `sudo clearwater-upgrade` in that order on each node.
+If you installed your system using the [Manual Install Instructions](Manual_Install), run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgradee` on each node.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure`, `sudo chef-client` and `sudo clearwater-upgrade` in that order on each node.
+* Run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client && sudo clearwater-upgrade` on each node.
 
 ## Seamless Upgrade
 
@@ -55,11 +55,11 @@ Bonos, and one Ellis, you should upgrade them in the following order:
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install) run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure` and `sudo clearwater-upgrade` in that order on each node in the order described above.
+If you installed your system using the [Manual Install Instructions](Manual_Install) run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node in the order described above.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo apt-get update`, `sudo apt-get install clearwater-infrastructure`, `sudo chef-client` and `sudo clearwater-upgrade` in that order on each node in the order described above.
+* Run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client && sudo clearwater-upgrade` on each node in the order described above.


### PR DESCRIPTION
We've changed the clearwater-upgrade script this sprint which means that clearwater-infrastructure needs to be updated before we run clearwater-upgrade. This is generally true, and hence I've added it to do the upgrade instructions.
