### PR TITLE
Sudo everywhere

### DIFF
--- a/docs/Clearwater_Elastic_Scaling.md
+++ b/docs/Clearwater_Elastic_Scaling.md
@@ -30,7 +30,7 @@ If you're scaling up your deployment, follow the following process:
 2.  Wait until the new nodes have fully joined the existing deployment. To check if a node has joined the deployment:
 
     * Run `/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health`. This should report that the local node is in all of its clusters and that the cluster is healthy.
-    * Run `/usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync`. This reports when the node has learned its configuration.
+    * Run `sudo /usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync`. This reports when the node has learned its configuration.
 
 3.  Update DNS to contain the new nodes.
 

--- a/docs/Manual_Install.md
+++ b/docs/Manual_Install.md
@@ -210,7 +210,7 @@ If you require I-CSCF functionality, log onto your sprout node and create `/etc/
        ]
     }
 
-Then upload it to the shared configuration database by running `/usr/share/clearwater/bin/upload_s-cscf_json`. This means that any sprout nodes that you add to the cluster will automatically learn the configuration.
+Then upload it to the shared configuration database by running `/usr/share/clearwater/bin/upload_scscf_json`. This means that any sprout nodes that you add to the cluster will automatically learn the configuration.
 
 ## Provision Telephone Numbers in Ellis
 

--- a/docs/Troubleshooting_and_Recovery.md
+++ b/docs/Troubleshooting_and_Recovery.md
@@ -80,7 +80,7 @@ Clearwater comes with a system that [automate clustering and configuration shari
 
 * The management system logs to `/var/log/clearwater-etcd`, `/var/log/clearwater-cluster-manager` and `/var/log/clearwater-config-manager`.
 * `/usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health` will display information about the state of the various data-store clusters used by Clearwater.
-* `/usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync` will display whether the node has learned shared configuration.
+* `sudo /usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync` will display whether the node has learned shared configuration.
 * The following commands can be useful for inspecting the state of the underlying etcd cluster used by the management system (replace `$local_ip` with the node's actual IP address)
 
         clearwater-etcdctl cluster-health


### PR DESCRIPTION
`check_config_sync` requires `sudo` (apparently python needs write access to it's source code...).  Also fixed a typo.
