### PR TITLE
[Reviewer: Ellie] Fix mkdocs 13.3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,4 @@
 site_name: Clearwater Docs Home
-repo_url: https://github.com/Metaswitch/clearwater-readthedocs
 pages:
 # Overview:
 - ['index.md', 'Home']

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,5 @@ pages:
 - ['Old_Manual_Install.md', 'Deprecated', 'Manual Install with Manual Clustering']
 
 theme: readthedocs
-theme_dir: "custom_theme"
-include_search: true
 use_directory_urls: false
 markdown_extensions: [sane_lists, admonition]


### PR DESCRIPTION
readthedocs.org have switched to a later version of mkdocs, so some of our custom theming is unnecessary (/actively harmful). This is the minimum change necessary to make it work again - I'll do further fixes later.

I've built it at http://clearwater.readthedocs.org/en/fix_mkdocs_13.3/index.html.
