### PR TITLE
[Reviewer: Rob] Update docs to reflect that latest version of chef

### DIFF
--- a/docs/Automated_Install.md
+++ b/docs/Automated_Install.md
@@ -17,7 +17,7 @@ The first phase:
 
 * [Installing a Chef server](Installing_a_Chef_server.md)
  - This server will track the created Clearwater nodes and allow the client access to them.
-* [Configuring a Chef client](Installing_a_Chef_client.md)
+* [Configuring a Chef workstation](Installing_a_Chef_workstation.md)
  - This machine will be the one on which deployments will be defined and managed.
 
 The second phase:

--- a/docs/Creating_a_deployment_environment.md
+++ b/docs/Creating_a_deployment_environment.md
@@ -4,8 +4,8 @@ These instructions make up part of the [automated install process](Automated_Ins
 
 ## Prerequisites
 
-* You must have [installed a Chef client](Installing_a_Chef_client.md).
-* You must have SSH access to the ubuntu user on the chef-client machine.
+* You must have [installed a Chef workstation](Installing_a_Chef_workstation.md).
+* You must have SSH access to the ubuntu user on the chef-workstation machine.
 
 ## Creating a keypair
 
@@ -15,7 +15,7 @@ Amazon will give you a `<keypair_name>`.pem file; copy that file to the `/home/u
 
 ## Creating the environment
 
-Before creating an environment, choose a name (e.g. "clearwater") which will be referred to as `<name>` in the following steps.  Now, on the chef-client machine, create a file in `~/chef/environments/<name>.rb` with the following contents:
+Before creating an environment, choose a name (e.g. "clearwater") which will be referred to as `<name>` in the following steps.  Now, on the chef-workstation machine, create a file in `~/chef/environments/<name>.rb` with the following contents:
 
     name "<name>"
     description "Clearwater deployment - <name>"

--- a/docs/Creating_a_deployment_environment.md
+++ b/docs/Creating_a_deployment_environment.md
@@ -5,7 +5,7 @@ These instructions make up part of the [automated install process](Automated_Ins
 ## Prerequisites
 
 * You must have [installed a Chef workstation](Installing_a_Chef_workstation.md).
-* You must have SSH access to the ubuntu user on the chef-workstation machine.
+* You must have SSH access to the ubuntu user on the chef workstation machine.
 
 ## Creating a keypair
 
@@ -15,7 +15,7 @@ Amazon will give you a `<keypair_name>`.pem file; copy that file to the `/home/u
 
 ## Creating the environment
 
-Before creating an environment, choose a name (e.g. "clearwater") which will be referred to as `<name>` in the following steps.  Now, on the chef-workstation machine, create a file in `~/chef/environments/<name>.rb` with the following contents:
+Before creating an environment, choose a name (e.g. "clearwater") which will be referred to as `<name>` in the following steps.  Now, on the chef workstation machine, create a file in `~/chef/environments/<name>.rb` with the following contents:
 
     name "<name>"
     description "Clearwater deployment - <name>"

--- a/docs/Creating_a_deployment_with_Chef.md
+++ b/docs/Creating_a_deployment_with_Chef.md
@@ -4,7 +4,7 @@ This is the final stage in creating a Clearwater deployment using the [automated
 
 ## Prerequisites
 
-* You must have [created the chef client machine](Installing_a_Chef_client.md) and have SSH access to the ubuntu user on it.
+* You must have [created the chef workstation machine](Installing_a_Chef_workstation.md) and have SSH access to the ubuntu user on it.
 * You must have [created a deployment environment](Creating_a_deployment_environment.md) and know its name, `<name>`.
 
 # Creating a Deployment
@@ -13,7 +13,7 @@ You now have two options - you can create an All-in-One node, where all the Clea
 
 ## Creating an All-in-One ("AIO") node
 
-To create a single machine instance running all the Clearwater components, run the following on the chef-client machine.
+To create a single machine instance running all the Clearwater components, run the following on the chef-workstation machine.
 
 	cd ~/chef
 	knife box create cw_aio -E <name>
@@ -26,7 +26,7 @@ The following modifier is available.
 
 ## Creating a larger deployment
 
-To kick off construction of the deployment, run the following on the chef-client machine.
+To kick off construction of the deployment, run the following on the chef-workstation machine.
 
     cd ~/chef
     knife deployment resize -E <name> --ralf-count 1 -V

--- a/docs/Creating_a_deployment_with_Chef.md
+++ b/docs/Creating_a_deployment_with_Chef.md
@@ -13,7 +13,7 @@ You now have two options - you can create an All-in-One node, where all the Clea
 
 ## Creating an All-in-One ("AIO") node
 
-To create a single machine instance running all the Clearwater components, run the following on the chef-workstation machine.
+To create a single machine instance running all the Clearwater components, run the following on the chef workstation machine.
 
 	cd ~/chef
 	knife box create cw_aio -E <name>
@@ -26,7 +26,7 @@ The following modifier is available.
 
 ## Creating a larger deployment
 
-To kick off construction of the deployment, run the following on the chef-workstation machine.
+To kick off construction of the deployment, run the following on the chef workstation machine.
 
     cd ~/chef
     knife deployment resize -E <name> --ralf-count 1 -V

--- a/docs/Installing_a_Chef_workstation.md
+++ b/docs/Installing_a_Chef_workstation.md
@@ -25,7 +25,7 @@ The Clearwater chef plugins use features from Ruby 1.9.3.  To start run the foll
 
     curl -L https://get.rvm.io | bash -s stable
 
-This may fail due to missing GPG signiatures. If this happens it will suggest a command to run to resolve the problem (e.g. gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3`). Run the command suggested, then run the above command again, which should now succeed).
+This may fail due to missing GPG signatures. If this happens it will suggest a command to run to resolve the problem (e.g. gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3`). Run the command suggested, then run the above command again, which should now succeed).
 
 Next install the required ruby version.
 

--- a/docs/Installing_a_Chef_workstation.md
+++ b/docs/Installing_a_Chef_workstation.md
@@ -13,7 +13,7 @@ These instructions cover commissioning a Chef client node on an EC2 server as pa
 
 Create a `t2.micro` AWS EC2 instance running `Ubuntu Server 14.04.2 LTS` using the AWS web interface.  Configure its security group to allow access on port 22 (for SSH). The SSH keypair you provide here is referred to below as `<amazon_ssh_key>`. It is easiest if you use the same SSH keypair for all of your instances.
 
-Configure a DNS entry for this machine, `chef-workstation.<zone>`. (The precise name isn't important, but we use this consistently in the documentation that follows.) It should have a non-aliased A record pointing at the public IP address of the instance as displayed in the EC2 console.
+Configure a DNS entry for this machine, `chef workstation.<zone>`. (The precise name isn't important, but we use this consistently in the documentation that follows.) It should have a non-aliased A record pointing at the public IP address of the instance as displayed in the EC2 console.
 
 Once the instance is up and running and you can connect to it over SSH, you may continue to the next steps.
 
@@ -38,7 +38,7 @@ At this point, `ruby --version` should indicate that 1.9.3 is in use.
 
 ## Installing the Clearwater Chef extensions
 
-On the chef-workstation machine, install git and dependent libraries.
+On the chef workstation machine, install git and dependent libraries.
 
     sudo apt-get install git libxml2-dev libxslt1-dev
 
@@ -64,9 +64,9 @@ You will need to configure yourself as a user on the chef server in order to use
     sudo chef-server-ctl user-create USER_NAME FIRST_NAME LAST_NAME EMAIL PASSWORD --filename USER_NAME.pem
     sudo chef-server-ctl org-user-add ORG_NAME USER_NAME --admin
 
-## Configure the chef-workstation machine
+## Configure the chef workstation machine
 
-Back on the chef-workstation machine, create a `.chef` folder in your home directory.
+Back on the chef workstation machine, create a `.chef` folder in your home directory.
 
     mkdir ~/.chef
 
@@ -79,7 +79,7 @@ Copy the validator key from the chef server to your client. You will need to eit
 or (on an intermediate box with the SSH key available)
 
     scp -i <amazon_ssh_key>.pem ubuntu@chef-server.<zone>:<org-name>-validator.pem .
-    scp -i <amazon_ssh_key>.pem <org-name>-validator.pem ubuntu@chef-workstation.<zone>:~/.chef/
+    scp -i <amazon_ssh_key>.pem <org-name>-validator.pem ubuntu@chef workstation.<zone>:~/.chef/
 
 Configure knife using the built in auto-configuration tool.
 

--- a/docs/Making_your_first_call.md
+++ b/docs/Making_your_first_call.md
@@ -46,7 +46,7 @@ If you installed an All-in-One node, your Ellis URL will be `http://<aio-identit
 
 In your browser, navigate to the Ellis URL you worked out above.
 
-Sign up as a new user, using the signup code you set as `signup_key` when [configuring your deployment](Installing_a_Chef_client.md#add-deployment-specific-configuration).
+Sign up as a new user, using the signup code you set as `signup_key` when [configuring your deployment](Installing_a_Chef_workstation.md#add-deployment-specific-configuration).
 
 Ellis will automatically allocate you a new number and display its password to you.  Remember this password as it will only be displayed once.  From now on, we will use `<username>` to refer to the SIP username (e.g. `6505551234`) and `<password>` to refer to the password.
 

--- a/docs/Manual_Install.md
+++ b/docs/Manual_Install.md
@@ -79,7 +79,7 @@ If you are creating a [geographically redundant deployment](Geographic_redundanc
 
 * `etcd_cluster` should contain the IP addresses of nodes in both sites
 *  you should set `local_site_name` and `remote_site_name` in `/etc/clearwater/local_config`.
-    
+
 These names are arbitrary, but should reflect the node's location (e.g. a node in site A should have
 `local_site_name=siteA` and `remote_site_name=siteB`, whereas a node in site B should have
 `local_site_name=siteB` and `remote_site_name=siteA`):
@@ -206,7 +206,7 @@ If you want your Sprout nodes to include Gemini/Memento Application Servers add 
     gemini_enabled='Y'
     memento_enabled='Y'
 
-See the [Chef instructions](Installing_a_Chef_client.md#add-deployment-specific-configuration) for more information on how to fill these in. The values marked `<secret>` **must** be set to secure values to protect your deployment from unauthorized access. To modify these settings after the deployment is created, follow [these instructions](Modifying_Clearwater_settings.md).
+See the [Chef instructions](Installing_a_Chef_workstation.md#add-deployment-specific-configuration) for more information on how to fill these in. The values marked `<secret>` **must** be set to secure values to protect your deployment from unauthorized access. To modify these settings after the deployment is created, follow [these instructions](Modifying_Clearwater_settings.md).
 
 Now run the following to upload the configuration to a shared database and propagate it around the cluster.
 

--- a/docs/Running_the_live_tests.md
+++ b/docs/Running_the_live_tests.md
@@ -6,7 +6,7 @@ The Clearwater team have put together a suite of live tests that can be run over
 
 * You've [installed Clearwater](Installation_Instructions.md)
 * You have an Ubuntu Linux machine available to drive the tests
- - If you installed through the automated install process, the chef-workstation is a perfectly good choice for this task
+ - If you installed through the automated install process, the chef workstation is a perfectly good choice for this task
 
 ## Installing dependencies
 

--- a/docs/Running_the_live_tests.md
+++ b/docs/Running_the_live_tests.md
@@ -6,7 +6,7 @@ The Clearwater team have put together a suite of live tests that can be run over
 
 * You've [installed Clearwater](Installation_Instructions.md)
 * You have an Ubuntu Linux machine available to drive the tests
- - If you installed through the automated install process, the chef-client is a perfectly good choice for this task
+ - If you installed through the automated install process, the chef-workstation is a perfectly good choice for this task
 
 ## Installing dependencies
 
@@ -36,7 +36,7 @@ Make sure that you have an SSH key - if not, see the [GitHub instructions](https
 The tests need your signup code to create a test user.
 You set this as `signup_key` during install:
 [manually in /etc/clearwater/shared_config](Manual_Install.md)
-or [automatically in knife.rb](Installing_a_Chef_client.md). For the rest of these instructions, the
+or [automatically in knife.rb](Installing_a_Chef_workstation.md). For the rest of these instructions, the
 signup code will be referred to as `<code>`.
 
 ## Running the tests against an All-in-One node

--- a/docs/WebRTC_support_in_Clearwater.md
+++ b/docs/WebRTC_support_in_Clearwater.md
@@ -87,7 +87,7 @@ TURN. Configure this as follows:
 
 -   On the 'expert mode' tab, fill in the following field with your
     SIP username and the TURN workaround password set by your administrator
-    (`turn_workaround` in [Installing a Chef client](Installing_a_Chef_client.md)).
+    (`turn_workaround` in [Installing a Chef workstation](Installing_a_Chef_workstation.md)).
     This is a workaround for Chrome WebRTC [issue
     1508](https://code.google.com/p/webrtc/issues/detail?id=1508) which
     will be fixed in Chrome 28 (not yet released).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ pages:
 - ['All_in_one_EC2_AMI_Installation.md', 'Installation', 'All in one EC2 AMI Installation']
 - ['All_in_one_OVF_Installation.md', 'Installation', 'All-in-one OVF Installation']
 - ['Installing_a_Chef_server.md', 'Installation', 'Installing a Chef server']
-- ['Installing_a_Chef_client.md', 'Installation', 'Installing a Chef client']
+- ['Installing_a_Chef_workstation.md', 'Installation', 'Installing a Chef workstation']
 - ['Creating_a_deployment_environment.md', 'Installation', 'Creating a deployment environment']
 - ['Creating_a_deployment_with_Chef.md', 'Installation', 'Creating a deployment with Chef']
 - ['Making_your_first_call.md', 'Installation', 'Making your first call']


### PR DESCRIPTION
Rob, please can you review this PR to update our docs to reflect how you install and use the latest chef. The main changes are:
- The process for installing the server is completely different.
- I have removed some unnecessary stuff from the chef client install. 
- I have changed the docs so that "chef client" refers to nodes and "chef workstation" refers to developer machines that run knife. This reflects the current chef documentation (e.g. https://docs.chef.io/workstation.html). 

Tested by running `mkdocs serve`. No errors reported and all modified pages looked fine. 
