### PR TITLE
[Reviewer: Rob] Chef docs tidy up.

### DIFF
--- a/docs/Installing_a_Chef_server.md
+++ b/docs/Installing_a_Chef_server.md
@@ -30,12 +30,6 @@ Follow steps 1-6 in the [chef docs](http://docs.chef.io/install_server.html).
 
 Once you have completed these steps, copy the `<chef-user-name>.pem` file off of the chef server - you will need it when installing a chef workstation.
 
-Next, install the chef server web UI by running the following commands.
-
-    sudo chef-server-ctl install opscode-manage
-    sudo chef-server-ctl reconfigure
-    sudo opscode-manage-ctl reconfigure
-
 ## Next steps
 
 Once your server is installed, you can continue on to [install a chef workstation](Installing_a_Chef_workstation.md).

--- a/docs/Installing_a_Chef_workstation.md
+++ b/docs/Installing_a_Chef_workstation.md
@@ -133,11 +133,6 @@ file.
     # must be validated or email sending will fail.
     knife[:email_sender]      = "clearwater@example.com"
 
-    # MMonit server credentials, if any.
-    knife[:mmonit_server]     = ""
-    knife[:mmonit_username]   = ""
-    knife[:mmonit_password]   = ""
-
 Fill in the values appropriate to your deployment using a text editor
 as directed.
 
@@ -160,10 +155,6 @@ as directed.
 
 * The SMTP credentials are required only for password recovery.
   If you leave them unchanged, this function will not work.
-
-* The M/Monit credentials are only required if you have an
-  [M/Monit](Configuring_MMonit.md) server. Otherwise you can leave them
-  unchanged.
 
 ## Test your settings
 

--- a/docs/Troubleshooting_and_Recovery.md
+++ b/docs/Troubleshooting_and_Recovery.md
@@ -62,18 +62,6 @@ Ralf logs to `/var/log/ralf/ralf*.txt`.  By default, it is set to log level 2, w
 
 If you see Ralf dying/restarting with no apparent cause in `/var/log/ralf/ralf*.txt`, check `/var/log/monit.log` and `/var/log/syslog` around that time - these can sometimes give clues as to the cause.
 
-## Chef
-
-*   After stopping/restarting the Chef server, you might see logs as follows.
-
-        merb : chef-server (api) : worker (port 4000) ~ Connection failed - user: chef - (Bunny::ProtocolError)
-
-    This can be worked around by recreating the chef account, as follows, including the `<rabbitMQPass>` you supplied when you [installed the Chef server](Installing_a_Chef_server.md).
-
-        rabbitmqctl add_vhost /chef
-        rabbitmqctl add_user chef <rabbitMQPass>
-        rabbitmqctl set_permissions -p /chef chef ".*" ".*" ".*"
-
 ## Deployment Management
 
 Clearwater comes with a system that [automate clustering and configuration sharing](Automatic_Clustering_Config_Sharing.md). If you cannot scale your deployment up or down, or if configuration changes are not being applied, this system may not be working.


### PR DESCRIPTION
Hi Rob, please can you review these tweaks to the public docs covering chef:
- No longer instruct users to install the web UI. 
- Remove references to mmonit.
- Remove the out-of-date chef server troubleshooting section. 

Tested by running mkdocs - no errors reported related to this change, and the changed pages look fine. 
