### PR TITLE
[Reviewer AMC] Remove mmonit port from port usage docs

### DIFF
--- a/docs/Clearwater_IP_Port_Usage.md
+++ b/docs/Clearwater_IP_Port_Usage.md
@@ -14,15 +14,11 @@ They also need the following ports open to the world (`0.0.0.0/0`):
 
     TCP/22 for SSH access
 
-If your deployment uses monitoring software ([cacti](http://www.cacti.net/) or [m/monit](http://mmonit.com/) for example), each node will also have to open appropriate ports for those services.
+If your deployment uses SNMP monitoring software ([cacti](http://www.cacti.net/) for example), each node will also have to open appropriate ports for this service.
 
-* SNMP (e.g. for cacti)
+* SNMP
 
         UDP/161-162
-
-* M/Monit
-
-        TCP/2812
 
 If your deployment uses our [automatic clustering and configuration sharing](Automatic_Clustering_Config_Sharing) feature, open the following ports between every node
 


### PR DESCRIPTION
The ability to monitor Clearwater remotely via mmonit was apparently removed with https://github.com/Metaswitch/clearwater-infrastructure/commit/e8db4cd416190ecf4c4b33ba741259706ebf5e69 and https://github.com/Metaswitch/clearwater-readthedocs/pull/76.  This PR removes the reference to it in port usage documentation
