### PR TITLE
[Reviewer: None] Fix up docs to link to chef_base role.

### DIFF
--- a/docs/Creating_a_deployment_environment.md
+++ b/docs/Creating_a_deployment_environment.md
@@ -40,7 +40,7 @@ By default, your deployment will be created in the US East (North Virginia) regi
 *   set the `availability_zones` property correspondingly (e.g. `["us-west-2a", "us-west-2b"]`)
 *   open `~/chef/plugins/knife/boxes.rb`, search for `@@default_image`, and comment in the EC2 AMI entry for the region you desire.
 
-These fields override attributes defined and documented in the [clearwater-infrastructure role](https://github.com/Metaswitch/chef/blob/master/roles/clearwater-infrastructure.rb).
+These fields override attributes defined and documented in the [chef-base role](https://github.com/Metaswitch/chef/blob/master/roles/chef-base.rb).
 
 If you want to use a different SIP registration period from the default (which is 5 minutes) add a line like `"reg_max_expires" => <timeout_in_secs>,` to the `override_attributes "clearwater"` block.
 


### PR DESCRIPTION
The clearwater-infrastructure role was removed in a previous refactor.

I talked this through with Rob.
