### PR TITLE
[Reviewer: Ellie] Consolidate statistics listings

### DIFF
--- a/docs/Clearwater_SNMP_Statistics.md
+++ b/docs/Clearwater_SNMP_Statistics.md
@@ -1,6 +1,6 @@
 # SNMP Statistics
 
-Clearwater provides a set of statistics about the performance of each Clearwater nodes over SNMP. Currently, this is available on Bono, Sprout, Ralf and Homestead nodes, and the MMTel, Call Diversion, Memento and Gemini Application Server nodes. A number of the statistics we offer detail the current state of the system in use, and as such are termed 'Stateful' statistics. These statistics will be marked with a '(*)' below, and more information on them can be found [here](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html)
+Clearwater provides a set of statistics about the performance of each Clearwater nodes over SNMP. Currently, this is available on Bono, Sprout, Ralf and Homestead nodes, and the MMTel, Call Diversion, Memento and Gemini Application Server nodes. A number of the statistics we offer detail the current state of the system in use, and as such are termed 'Stateful' statistics. These statistics will be marked as '(stateful)' below, and more information on them can be found [here](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html)
 
 ## Configuration
 
@@ -109,12 +109,12 @@ Sprout nodes provide the following statistics:
 * The current permitted request rate.
 * The number of incoming INVITE transactions for the S-CSCF that were cancelled before a 1xx response was seen, indexed by time period.
 * The number of incoming INVITE transactions for the S-CSCF that were cancelled after a 1xx response was seen, indexed by time period (these INVITE cancellation statistics can be used to distinguish between the case where an INVITE was cancelled because the call rang but wasn't answered and the case where it failed due to network issues and never got through in the first place).
-* The average count, variance, and high and low watermarks for the number of registrations, indexed by time period. (*)
-* The average count, variance, and high and low watermarks for the number of bindings, indexed by time period. (*)
-* The average count, variance, and high and low watermarks for the number of subscriptions, indexed by time period. (*)
-* The number of registrations active at the time queried. (*)
-* The number of bindings active at the time queried. (*)
-* The number of subscriptions active at the time queried. (*)
+* The average count, variance, and high and low watermarks for the number of registrations, indexed by time period. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The average count, variance, and high and low watermarks for the number of bindings, indexed by time period. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The average count, variance, and high and low watermarks for the number of subscriptions, indexed by time period. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The number of registrations active at the time queried. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The number of bindings active at the time queried. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The number of subscriptions active at the time queried. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
 
 ### Ralf statistics
 
@@ -126,8 +126,8 @@ Ralf nodes provide the following statistics:
 * The transfer rate (in bytes/second) of data during this resynchronization, over the last 5 seconds (overall, and per bucket).
 * The number of remaining nodes to query during the current Chronos scaling operation.
 * The number of timers, and number of invalid timers, processed over the last 5 seconds.
-* The average count, variance, and high and low watermarks for the number of calls, indexed by time period. (*)
-* The number of calls active at the time queried. (*)
+* The average count, variance, and high and low watermarks for the number of calls, indexed by time period. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
+* The number of calls active at the time queried. ([stateful](https://clearwater.readthedocs.io/en/stable/Clearwater_Stateful_Statistics/index.html))
 
 ### Homestead Statistics
 

--- a/docs/Clearwater_SNMP_Statistics.md
+++ b/docs/Clearwater_SNMP_Statistics.md
@@ -109,10 +109,12 @@ Sprout nodes provide the following statistics:
 * The current permitted request rate.
 * The number of incoming INVITE transactions for the S-CSCF that were cancelled before a 1xx response was seen, indexed by time period.
 * The number of incoming INVITE transactions for the S-CSCF that were cancelled after a 1xx response was seen, indexed by time period (these INVITE cancellation statistics can be used to distinguish between the case where an INVITE was cancelled because the call rang but wasn't answered and the case where it failed due to network issues and never got through in the first place).
-* The average, variance, high water mark and low water mark for the number of Registered subscribers, indexed by time period. (*)
-* The instantaneous count for the number of Registered subscribers. (*)
-* The average, variance, high water mark and low water mark for the number of SIP SUBSCRIBEs, indexed by time period. (*)
-* The instantaneous count for the number of active SIP SUBSCRIBEs. (*)
+* The average count, variance, and high and low watermarks for the number of registrations, indexed by time period. (*)
+* The average count, variance, and high and low watermarks for the number of bindings, indexed by time period. (*)
+* The average count, variance, and high and low watermarks for the number of subscriptions, indexed by time period. (*)
+* The number of registrations active at the time queried. (*)
+* The number of bindings active at the time queried. (*)
+* The number of subscriptions active at the time queried. (*)
 
 ### Ralf statistics
 
@@ -124,8 +126,8 @@ Ralf nodes provide the following statistics:
 * The transfer rate (in bytes/second) of data during this resynchronization, over the last 5 seconds (overall, and per bucket).
 * The number of remaining nodes to query during the current Chronos scaling operation.
 * The number of timers, and number of invalid timers, processed over the last 5 seconds.
-* The average, variance, high water mark and low water mark for the number of active calls, indexed by time period. (*)
-* The instantaneous count for the number of active calls. (*)
+* The average count, variance, and high and low watermarks for the number of calls, indexed by time period. (*)
+* The number of calls active at the time queried. (*)
 
 ### Homestead Statistics
 

--- a/docs/Clearwater_Stateful_Statistics.md
+++ b/docs/Clearwater_Stateful_Statistics.md
@@ -1,6 +1,6 @@
 # Stateful Statistics
 
-Clearwater is designed to be as stateless as possible, simplifying redundancy, and making it ideal for virtualised and cloud-based deployment. However, through use of our distributed timer store, Chronos, Clearwater is able to maintain a number of stateful statistics. As components use timers to maintain stateful functionality without actually remaining independently aware of state, we can form statistics based on these, rather than needing each main process to maintain and report state. Currently Sprout and Ralf nodes expose stateful statistics. To see the full list of statistics available, check [here](https://clearwater.readthedocs.io/en/stable/Clearwater_SNMP_Statistics/index.html); stateful statistics are marked with a '(*)' to distinguish them.
+Clearwater is designed to be as stateless as possible, simplifying redundancy, and making it ideal for virtualised and cloud-based deployment. However, through use of our distributed timer store, Chronos, Clearwater is able to maintain a number of stateful statistics. As components use timers to maintain stateful functionality without actually remaining independently aware of state, we can form statistics based on these, rather than needing each main process to maintain and report state. Currently Sprout and Ralf nodes expose stateful statistics. To see the full list of statistics available, check [here](https://clearwater.readthedocs.io/en/stable/Clearwater_SNMP_Statistics/index.html); stateful statistics are marked as '(stateful)' to distinguish them.
 
 
 ## Configuration
@@ -16,6 +16,7 @@ e.g. Consider a deployment with three Sprout nodes. If ten registrations are set
 * Node 1 :-  6 Registrations
 * Node 2 :-  7 Registrations
 * Node 3 :-  7 Registrations
+
 
 This does not mean that the number of registrations has doubled, nor is it representative of the number of registrations that each node actually handled. It is simply directly the number of timers held on each node tagged as registrations.  
 To then calculate the number of registrations actually active in the deployment, one takes the total and divides it by the replication factor, in this example 2.

--- a/docs/Clearwater_Stateful_Statistics.md
+++ b/docs/Clearwater_Stateful_Statistics.md
@@ -1,4 +1,7 @@
-Clearwater is designed to be as stateless as possible, simplifying redundancy, and making it ideal for virtualised and cloud-based deployment. However, through use of our distributed timer store, Chronos, Clearwater is able to maintain a number of stateful statistics. As components use timers to maintain stateful functionality without actually remaining independently aware of state, we can form statistics based on these, rather than needing each main process to maintain and report state. Currently Sprout and Ralf nodes expose stateful statistics.
+# Stateful Statistics
+
+Clearwater is designed to be as stateless as possible, simplifying redundancy, and making it ideal for virtualised and cloud-based deployment. However, through use of our distributed timer store, Chronos, Clearwater is able to maintain a number of stateful statistics. As components use timers to maintain stateful functionality without actually remaining independently aware of state, we can form statistics based on these, rather than needing each main process to maintain and report state. Currently Sprout and Ralf nodes expose stateful statistics. To see the full list of statistics available, check [here](https://clearwater.readthedocs.io/en/stable/Clearwater_SNMP_Statistics/index.html); stateful statistics are marked with a '(*)' to distinguish them.
+
 
 ## Configuration
 
@@ -20,24 +23,6 @@ To then calculate the number of registrations actually active in the deployment,
 > (  6    +   7    +   7   ) / 2  => 10 Active registrations
 
 Note: These statistics may be inaccurate in systems with a failing node. As such they should be considered unreliable while any alarms are raised, particularly those relating to Chronos.
-
-### Sprout statistics
-
-Sprout nodes provide the following statistics:
-
-* The average count, variance, and high and low watermarks for the number of registrations, indexed by time period.
-* The average count, variance, and high and low watermarks for the number of bindings, indexed by time period.
-* The average count, variance, and high and low watermarks for the number of subscriptions, indexed by time period.
-* The number of registrations active at the time queried.
-* The number of bindings active at the time queried.
-* The number of subscriptions active at the time queried.
-
-### Ralf statistics
-
-Ralf nodes provide the following statistics:
-
-* The average count, variance, and high and low watermarks for the number of calls, indexed by time period.
-* The number of calls active at the time queried.
 
 ## Technical details
 


### PR DESCRIPTION
I've taken the wording that was in the stateful stats doc, as i think it was clearer and more up to date, but I've consolidated all statistics to be listed in the main SNMP statistics article.
Also added a heading to the stateful stats doc.

The weird italicisation in the diffs below doesn't appear to show up in the rendered markdown doc, so i'm assuming that's just github having a stroke or something. If it shows up on readthedocs, obviously i'll come back to fixing it.
