### PR TITLE
[Reviewer: Ellie] Turn off 'Edit on Github' link

### DIFF
--- a/autogenerated_rst_docs/conf.py
+++ b/autogenerated_rst_docs/conf.py
@@ -28,3 +28,15 @@ exclude_patterns = ['_build']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ProjectClearwaterdoc'
+
+# The readthedocs code updates the html_context variable, setting
+# display_github to True. As we don't want to display the "Edit on Github"
+# link, we create a subclass of dict that always sets display_github back to
+# False after being updated.
+class NoGithubDict(dict):
+    def update(self, other_dict):
+        dict.update(self, other_dict)
+        self['display_github'] = False
+
+html_context = NoGithubDict()
+

--- a/autogenerated_rst_docs/conf.py
+++ b/autogenerated_rst_docs/conf.py
@@ -38,6 +38,7 @@ class NoGithubDict(dict):
         global html_context
         html_context = other_dict
         html_context['display_github'] = False
+        html_context['show_source'] = False
 
 html_context = NoGithubDict()
 

--- a/autogenerated_rst_docs/conf.py
+++ b/autogenerated_rst_docs/conf.py
@@ -35,8 +35,9 @@ htmlhelp_basename = 'ProjectClearwaterdoc'
 # False after being updated.
 class NoGithubDict(dict):
     def update(self, other_dict):
-        dict.update(self, other_dict)
-        self['display_github'] = False
+        global html_context
+        html_context = other_dict
+        html_context['display_github'] = False
 
 html_context = NoGithubDict()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ All the source code is on [GitHub](https://github.com/Metaswitch), in the follow
 
 You can contribute by making a GitHub pull request. See our documented [Pull request process](Pull_request_process.md).
 
+If you want to contribute specifically to this documentation (e.g. to fix a typo or document a missing option), the Markdown files for it are at <https://github.com/Metaswitch/clearwater-readthedocs>.
+
 There is more information about contributing to Project Clearwater on the [community page of our project website](http://www.projectclearwater.org/community/).
 
 ## Help


### PR DESCRIPTION
You asked if we could do anything about the 'Edit on Github' link on our docs being wrong- I originally thought doing anything would need a ReadTheDocs code change, but actually this (quite hacky) change removes it.

The interesting line of ReadTheDocs code is https://github.com/rtfd/readthedocs.org/blob/fdf28e97fb161b02cb4b5d78f906a3c9df38209f/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl#L121 - it creates a `context` dictionary where `display_github` is always set to True if your docs come from a Github URL, then calls `html_context.update(context)`, overriding any keys in the user-supplied `html_context` dictionary with the ones in `context`.

This "fixes" that by declaring html_context as a new class, with an `update` method that sets `display_github` back to `False`. You can see this branch in action at http://docs.projectclearwater.org/en/no_github/.
