### PR TITLE
[Reviewer: Rob] Remove bono_hostname (as it doesn't do anything)

### DIFF
--- a/docs/Clearwater_Configuration_Options_Reference.md
+++ b/docs/Clearwater_Configuration_Options_Reference.md
@@ -54,7 +54,6 @@ This section describes options for the basic configuration of a Clearwater deplo
 
 * `home_domain` - this is the main SIP domain of the deployment, and determines which SIP URIs Clearwater will treat as local. It will usually be a hostname resolving to all the P-CSCFs (e.g. the Bono nodes). Other domains can be specified through additional_home_domains, but Clearwater will treat this one as the default (for example, when handling `tel:` URIs).
 * `sprout_hostname` - a hostname that resolves by DNS round-robin to all Sprout nodes in the cluster.
-* `bono_hostname` - a hostname that resolves by DNS round-robin to all Bono nodes in the cluster.
 * `hs_hostname` - a hostname that resolves by DNS round-robin to all Homesteads in the cluster. Should include the HTTP port (usually 8888). This is also used (without the port) as the Origin-Realm of the Diameter messages Homestead sends.
 * `hs_provisioning_hostname` - a hostname that resolves by DNS round-robin to all Homesteads in the cluster. Should include the HTTP provisioning port (usually 8889). Not needed when using an external HSS.
 * `ralf_hostname` - a hostname that resolves by DNS round-robin to all Ralf nodes in the cluster. Should include the port (usually 9888). This is also used (without the port) as the Origin-Realm of the Diameter messages Ralf sends. Optional if no Ralf nodes exist.


### PR DESCRIPTION
The `bono_hostname` option doesn't do anything.  Please can you review its removal?
