### PR TITLE
[Reviewer: Seb] Fix backup commands

### DIFF
--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -84,7 +84,7 @@ To take a manual backup on Homestead, Homer or Memento, run
 
 *   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning` and `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache` on Homestead
 *   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer` on Homer
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh memento` on Memento.
+*   `sudo /usr/share/clearwater/bin/do_backup.sh memento` on Memento.
 
 This produces output of the following form, reporting the successfully-created backup.
 

--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -1,6 +1,6 @@
 # Backups
 
-Within a Clearwater deployment, ellis, homestead, homer and memento all store persistent data.  (Bono and sprout do not.)  To prevent data loss in disaster scenarios, ellis, homestead, homer and memento all have data backup and restore mechanisms.  Specifically, all support
+Within a Clearwater deployment, Ellis, Homestead, Homer and Memento all store persistent data (Bono and Sprout do not). To prevent data loss in disaster scenarios, Ellis, Homestead, Homer and Memento all have data backup and restore mechanisms.  Specifically, all support
 
 *   manual backup
 *   periodic automated local backup
@@ -13,15 +13,15 @@ This document describes
 *   the periodic automated local backup behavior
 *   how to restore from a backup.
 
-Note that if your Clearwater deployment is [integrated with an external HSS](External_HSS_Integration.md), the HSS is the master of ellis and homestead's data, and those nodes do not need to be backed up.  However, homer's data still needs to be backed up.
+Note that if your Clearwater deployment is [integrated with an external HSS](External_HSS_Integration.md), the HSS is the master of Ellis and Homestead's data, and those nodes do not need to be backed up.  However, Homer's data still needs to be backed up.
 
 ## Listing Backups
 
-The process for listing backups varies between ellis and homestead, homer and memento.
+The process for listing backups varies between Ellis and Homestead, Homer and Memento.
 
 ### Ellis
 
-To list the backups that have been taken on ellis, run `sudo /usr/share/clearwater/ellis/backup/list_backups.sh`.
+To list the backups that have been taken on Ellis, run `sudo /usr/share/clearwater/ellis/backup/list_backups.sh`.
 
     Backups for ellis:
     1372294741  /usr/share/clearwater/ellis/backup/backups/1372294741
@@ -31,13 +31,13 @@ To list the backups that have been taken on ellis, run `sudo /usr/share/clearwat
 
 ### Homestead, Homer and Memento
 
-Homestead actually contains two databases (`homestead_provisioning` and `homestead_cache`) and these must be backed up together.  This is why there are two commands for each homestead operation.  Homer and memento only contain one database and so there is only one command for each operation.
+Homestead actually contains two databases (`homestead_provisioning` and `homestead_cache`) and these must be backed up together.  This is why there are two commands for each Homestead operation.  Homer and Memento only contain one database and so there is only one command for each operation.
 
-To list the backups that have been taken on homestead, homer or memento, run
+To list the backups that have been taken on Homestead, Homer or Memento, run
 
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/list_backups.sh homestead_provisioning` and `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/list_backups.sh homestead_cache` for homestead
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/list_backups.sh homer` for homer
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/list_backups.sh memento` for memento.
+*   `sudo /usr/share/clearwater/bin/list_backups.sh homestead_provisioning` and `sudo /usr/share/clearwater/bin/list_backups.sh homestead_cache` for Homestead
+*   `sudo /usr/share/clearwater/bin/list_backups.sh homer` for Homer
+*   `sudo /usr/share/clearwater/bin/list_backups.sh memento` for Memento.
 
 This produces output of the following form, listing each of the available backups.
 
@@ -47,13 +47,13 @@ This produces output of the following form, listing each of the available backup
     provisioning1372813082506
     provisioning1372813143119
 
-You can also specify a directory to search in for backups, e.g. for homestead:
+You can also specify a directory to search in for backups, e.g. for Homestead:
 
-`sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/list_backups.sh homestead_provisioning <backup dir>`
+`sudo /usr/share/clearwater/bin/list_backups.sh homestead_provisioning <backup dir>`
 
 ## Taking a Manual Backup
 
-The process for taking a manual backup varies between ellis and homestead, homer and memento.  Note that in all cases,
+The process for taking a manual backup varies between Ellis and Homestead, Homer and Memento.  Note that in all cases,
 
 *   the backup is stored locally and should be copied to a secure backup server to ensure resilience
 *   this process only backs up a single local node, so the same process must be run on all nodes in a cluster to ensure a complete set of backups
@@ -62,7 +62,7 @@ The process for taking a manual backup varies between ellis and homestead, homer
 
 ### Ellis
 
-To take a manual backup on ellis, run `sudo /usr/share/clearwater/ellis/backup/do_backup.sh`.
+To take a manual backup on Ellis, run `sudo /usr/share/clearwater/ellis/backup/do_backup.sh`.
 
 This produces output of the following form, reporting the successfully-created backup.
 
@@ -76,15 +76,15 @@ This file is only accessible by the root user.  To copy it to the current user's
     sudo bash -c 'cp /usr/share/clearwater/ellis/backup/backups/'$snapshot'/db_backup.sql ~'$USER' &&
                   chown '$USER.$USER' db_backup.sql'
 
-This file can, and should, be copied off the ellis node to a secure backup server.
+This file can, and should, be copied off the Ellis node to a secure backup server.
 
 ### Homestead, Homer and Memento
 
-To take a manual backup on homestead, homer or memento, run
+To take a manual backup on Homestead, Homer or Memento, run
 
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning` and `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache` on homestead
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer` on homer
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh memento` on memento.
+*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning` and `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache` on Homestead
+*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer` on Homer
+*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh memento` on Memento.
 
 This produces output of the following form, reporting the successfully-created backup.
 
@@ -103,14 +103,14 @@ These should be copied off the node to a secure backup server.  For example, fro
 
 ## Periodic Automated Local Backups
 
-Ellis, homestead, homer and memento are all automatically configured to take daily backups if you've installed them through chef, at midnight local time every night.
+Ellis, Homestead, Homer and Memento are all automatically configured to take daily backups if you've installed them through chef, at midnight local time every night.
 
 If you want to turn this on, edit your crontab by running `sudo crontab -e` and add the following lines if not already present:
 
-*   `0 0 * * * /usr/share/clearwater/ellis/backup/do_backup.sh` on ellis
-*   `0 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning` and `5 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache` on homestead
-*   `0 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer` on homer
-*   `0 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh memento` on memento.
+*   `0 0 * * * /usr/share/clearwater/ellis/backup/do_backup.sh` on Elis
+*   `0 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning` and `5 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache` on Homestead
+*   `0 0 * * * /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer` on Homer
+*   `0 0 * * * /usr/share/clearwater/bin/do_backup.sh memento` on Memento.
 
 These backups are stored locally, in the same locations as they would be generated for a manual backup.
 
@@ -120,35 +120,35 @@ There are three stages to restoring from a backup.
 
 1.  Copying the backup files to the correct location.
 2.  Running the restore backup script.
-3.  Synchronizing ellis, homestead, homer and memento's views of the system state.
+3.  Synchronizing Ellis, Homestead, Homer and Memento's views of the system state.
 
 **This process will impact service and overwrite data in your database.**
 
 ### Copying Backup Files
 
-The first step in restoring from a backup is getting the backup files/directories into the correct locations on the ellis, homer, homestead or memento node.
+The first step in restoring from a backup is getting the backup files/directories into the correct locations on the Ellis, Homer, Homestead or Memento node.
 
 If you are restoring from a backup that was taken on the node on which you are restoring (and haven't moved it), you can just move onto the next step.
 
 If not, create a directory on your system that you want to put your backups into (we'll use `~/backup` in this example). Then copy the backups there.  For example, from a remote location that contains your backup directory `<snapshot>` execute `scp -r <snapshot> ubuntu@<homestead node>:backup/<snapshot>`.
 
-On ellis, run the following commands.
+On Ellis, run the following commands.
 
     snapshot=<snapshot>
     sudo chown root.root db_backup.sql
     sudo mkdir -p /usr/share/clearwater/ellis/backup/backups/$snapshot
     sudo mv ~/backup/$snapshot/db_backup.sql /usr/share/clearwater/ellis/backup/backups/$snapshot
 
-On homestead/homer/memento there is no need to further move the files as the backup script takes a optional backup directory parameter.
+On Homestead/Homer/Memento there is no need to further move the files as the backup script takes a optional backup directory parameter.
 
 ### Running the Restore Backup Script
 
 To actually restore from the backup file, run
 
-*   `sudo /usr/share/clearwater/ellis/backup/restore_backup.sh <snapshot>` on ellis
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/restore_backup.sh homestead_provisioning <snapshot> <backup directory>` and `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/restore_backup.sh homestead_cache <snapshot> <backup directory>` on homestead
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/restore_backup.sh homer <snapshot> <backup directory>` on homer
-*   `sudo /usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/restore_backup.sh memento <snapshot> <backup directory>` on memento.
+*   `sudo /usr/share/clearwater/ellis/backup/restore_backup.sh <snapshot>` on Ellis
+*   `sudo /usr/share/clearwater/bin/restore_backup.sh homestead_provisioning <snapshot> <backup directory>` and `sudo /usr/share/clearwater/bin/restore_backup.sh homestead_cache <snapshot> <backup directory>` on Homestead
+*   `sudo /usr/share/clearwater/bin/restore_backup.sh homer <snapshot> <backup directory>` on Homer
+*   `sudo /usr/share/clearwater/bin/restore_backup.sh memento <snapshot> <backup directory>` on Memento.
 
 Ellis will produce output of the following form.
 
@@ -165,7 +165,7 @@ Ellis will produce output of the following form.
     /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */
     --------------
 
-Homestead, homer or memento will produce output of the following form.
+Homestead, Homer or Memento will produce output of the following form.
 
     Will attempt to backup from backup 1372336442947
     Will attempt to backup from directory /home/ubuntu/bkp_test/
@@ -188,32 +188,32 @@ At this point, this node has been restored.
 ### Synchronization
 
 It is possible (and likely) that when backups are taken on different
-boxes the data will be out of sync, e.g. ellis will know about a
-subscriber, but there will no digest in homestead. To restore the system
-to a consistent state we have a synchronization tool within ellis, which
+boxes the data will be out of sync, e.g. Ellis will know about a
+subscriber, but there will no digest in Homestead. To restore the system
+to a consistent state we have a synchronization tool within Ellis, which
 can be run over a deployment to get the databases in sync. To run, log
-into an ellis box and execute:
+into an Ellis box and execute:
 
     cd /usr/share/clearwater/ellis
     sudo env/bin/python src/metaswitch/ellis/tools/sync_databases.py
 
 This will:
 
--   Run through all the lines on ellis that have an owner and verify
+-   Run through all the lines on Ellis that have an owner and verify
     that there is a private identity associated with the public
-    identity stored in ellis. If successful, it will verify that a
-    digest exists in homestead for that private identity.
+    identity stored in Ellis. If successful, it will verify that a
+    digest exists in Homestead for that private identity.
     If either of these checks fail, the line is considered lost and
-    is removed from ellis.
+    is removed from Ellis.
     If both checks pass, it will check that there is a valid IFC -
     if this is missing, it will be replaced with the default IFC.
--   Run through all the lines on ellis without an owner and make sure
-    there is no orphaned data in homestead and homer, i.e. deleting the
+-   Run through all the lines on Ellis without an owner and make sure
+    there is no orphaned data in Homestead and Homer, i.e. deleting the
     simservs, IFC and digest for those lines.
 
 ## Shared Configuration
 
-In addition to the data stored in ellis, homer, homestead and memento, a Clearwater deployment also has shared configuration that is [automatically shared between nodes](Automatic_Clustering_Config_Sharing.md). This is stored in a distributed database, and mirrored to files on the disk of each node.
+In addition to the data stored in Ellis, Homer, Homestead and Memento, a Clearwater deployment also has shared configuration that is [automatically shared between nodes](Automatic_Clustering_Config_Sharing.md). This is stored in a distributed database, and mirrored to files on the disk of each node.
 
 ### Backing Up
 


### PR DESCRIPTION
Fix up the backup commands to only run the necessary commands in the signaling namespace (and never for Memento as it doesn't support split networks). I've also tidied up process capitalization.