### PR TITLE
[Reviewer: Adam] Run nodetool repair after restoring a cassandra backup

### DIFF
--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -183,6 +183,10 @@ Homestead, Homer or Memento will produce output of the following form.
     sip_digests: Deleting old .db files...
     sip_digests: Restoring from backup: 1372336442947
 
+For Homestead, Homer or Memento, after restoring a backup you must also repair the node. To do this:
+- wait until the Cassandra process has restarted by running `sudo monit summary` and verifying that the `cassandra_process` is marked as `Running`
+- then run `sudo cw-run_in_signaling_namespace nodetool repair`
+
 At this point, this node has been restored.
 
 ### Synchronization

--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -183,9 +183,9 @@ Homestead, Homer or Memento will produce output of the following form.
     sip_digests: Deleting old .db files...
     sip_digests: Restoring from backup: 1372336442947
 
-For Homestead, Homer or Memento, after restoring a backup you must also repair the node. To do this:
+For Homestead, Homer or Memento, after restoring a backup you must also do the following:
 - wait until the Cassandra process has restarted by running `sudo monit summary` and verifying that the `cassandra_process` is marked as `Running`
-- then run `sudo cw-run_in_signaling_namespace nodetool repair`
+- run `sudo cw-run_in_signaling_namespace nodetool repair`
 
 At this point, this node has been restored.
 


### PR DESCRIPTION
The Cassandra docs say you should run `nodetool repair` after restoring from a backup (via the node restart method, which we use). This adds that to our instructions.