### PR TITLE
Reviewer SR2: Fix links to Automatic_Clustering_Config_Sharing.md

### DIFF
--- a/docs/Modifying_Clearwater_settings.md
+++ b/docs/Modifying_Clearwater_settings.md
@@ -11,7 +11,7 @@ Settings in `/etc/clearwater/shared_config` can be safely changed without entire
 To change one of these settings:
 
 *   Edit `/etc/clearwater/shared_config` on *one* node in each site and change to the new value.
-*   Run `cw-upload_shared_config` to upload the new config to etcd. The changes to the shared configuration are logged to `/var/log/syslog` and to the console. Each node in the site picks up the changed shared configuration (using Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing) functionality) and safely restarts itself to use it.
+*   Run `cw-upload_shared_config` to upload the new config to etcd. The changes to the shared configuration are logged to `/var/log/syslog` and to the console. Each node in the site picks up the changed shared configuration (using Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing.md) functionality) and safely restarts itself to use it.
 *   You can check which nodes are using the new shared config by running `cw-check_restart_queue_state`. If this command shows that there's been an error (i.e. a node wasn't able to restart after picking up the new config), simply fix the `/etc/clearwater/shared_config` and run the `cw-upload_shared_config` script again.
 
 ## Modifying Sprout JSON Configuration
@@ -28,7 +28,7 @@ To change one of these files:
 
 * Edit the file on *one* of your sprout nodes in each site.
 * Run one of `sudo cw-upload_{scscf|bgcf|enum}_json` depending on which file you modified.
-* The change will be automatically propagated around the site (by Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing) functionality) and will start being used.
+* The change will be automatically propagated around the site (by Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing.md) functionality) and will start being used.
 
 ## Modifying DNS Config
 
@@ -40,7 +40,7 @@ To change this file:
 
 * Edit the file on one of your nodes in each site.
 * Run `sudo /usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_config`.
-* The change will be automatically propagated around the site (using Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing) functionality) and will start being used.
+* The change will be automatically propagated around the site (using Clearwater's [automatic configuration sharing](Automatic_Clustering_Config_Sharing.md) functionality) and will start being used.
 
 ## Starting from scratch
 


### PR DESCRIPTION
Fixes a few links in http://clearwater.readthedocs.io/en/stable/Modifying_Clearwater_settings.html which AL6 raised as broken.

(Am I doing this right? PR into master? I can't remember how clearwater-readthedocs works :confounded:)