### PR TITLE
[Reviewer: Steve] Document `dns_timeout`

### DIFF
--- a/docs/Clearwater_Configuration_Options_Reference.md
+++ b/docs/Clearwater_Configuration_Options_Reference.md
@@ -208,6 +208,7 @@ This section describes optional configuration options, particularly for ensuring
 * `reject_if_no_matching_ifcs` - when set to 'Y' Clearwater will reject any initial requests that don't have any matching iFCs that can be applied to them. This option is not enabled by default.
 * `dummy_app_server` - this field allows the name of a dummy application server to be specified. If an iFC contains this dummy application server, then no application server will be invoked when this iFC is triggered.
 * `http_acr_logging` when set to 'Y', Clearwater will log the bodies of HTTP requests made to Ralf.  This provides additional diagnostics, but increases the volume of data sent to SAS.
+* `dns_timeout` - The time in milliseconds that Clearwater will wait for a response from the DNS server (defaults to 200 milliseconds).
 
 ### Experimental options
 


### PR DESCRIPTION
This was added a little while ago, but not documented. Steve's approved the wording out-of-band.