### PR TITLE
Add entry for Diameter watchdog timer options

### DIFF
--- a/docs/Clearwater_Configuration_Options_Reference.md
+++ b/docs/Clearwater_Configuration_Options_Reference.md
@@ -144,6 +144,8 @@ This section describes optional configuration options, particularly for ensuring
 * `enforce_global_only_lookups` - by default, Clearwater will do ENUM lookups for SIP and Tel URIs containing global and local numbers (as defined in RFC 3966). When this option is set to ‘Y’, Clearwater will only do ENUM lookups for SIP and Tel URIs that contain global numbers.
 * `hs_listen_port` - the Diameter port on which the homestead process on Dime listens. Defaults to 3868.
 * `ralf_listen_port`  - the Diameter port on which the ralf process on Dime listens. Defaults to 3869 to avoid clashes with the homestead process.
+* `homestead_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the homestead process. Defaults to 30 and must be set to at least 6.
+* `ralf_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the ralf process. Defaults to 30 and must be set to at least 6.
 * `alias_list` - this defines additional hostnames and IP addresses which Sprout or Bono will treat as local for the purposes of SIP routing (e.g. when removing Route headers).
 * `bono_alias_list` - this defines additional hostnames and IP addresses specifically for Bono which will be treated as local for the purposes of SIP routing.
 * `default_session_expires` - determines the Session-Expires value which Sprout will add to INVITEs, to force UEs to send keepalive messages during calls so they can be tracked for billing purposes. This cannot be set to a value less than 90 seconds, as specified in [RFC 4028, section 4](https://tools.ietf.org/html/rfc4028#section-4).

--- a/docs/Clearwater_Configuration_Options_Reference.md
+++ b/docs/Clearwater_Configuration_Options_Reference.md
@@ -144,8 +144,8 @@ This section describes optional configuration options, particularly for ensuring
 * `enforce_global_only_lookups` - by default, Clearwater will do ENUM lookups for SIP and Tel URIs containing global and local numbers (as defined in RFC 3966). When this option is set to ‘Y’, Clearwater will only do ENUM lookups for SIP and Tel URIs that contain global numbers.
 * `hs_listen_port` - the Diameter port on which the homestead process on Dime listens. Defaults to 3868.
 * `ralf_listen_port`  - the Diameter port on which the ralf process on Dime listens. Defaults to 3869 to avoid clashes with the homestead process.
-* `homestead_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the homestead process. Defaults to 30 and must be set to at least 6.
-* `ralf_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the ralf process. Defaults to 30 and must be set to at least 6.
+* `homestead_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the homestead process. Defaults to 30 and must be set to an integer that is at least 6.
+* `ralf_diameter_watchdog_timer` - the delay in seconds before a device watchdog message is sent on an unresponsive Diameter connection by the ralf process. Defaults to 30 and must be set to an integer that is at least 6.
 * `alias_list` - this defines additional hostnames and IP addresses which Sprout or Bono will treat as local for the purposes of SIP routing (e.g. when removing Route headers).
 * `bono_alias_list` - this defines additional hostnames and IP addresses specifically for Bono which will be treated as local for the purposes of SIP routing.
 * `default_session_expires` - determines the Session-Expires value which Sprout will add to INVITEs, to force UEs to send keepalive messages during calls so they can be tracked for billing purposes. This cannot be set to a value less than 90 seconds, as specified in [RFC 4028, section 4](https://tools.ietf.org/html/rfc4028#section-4).


### PR DESCRIPTION
This change adds entries for the Diameter watchdog timer options to be introduced in [#480](https://github.com/Metaswitch/homestead/pull/480) and [#289](https://github.com/Metaswitch/ralf/pull/289).