### PR TITLE
Insert line breaks into long commands.

### DIFF
--- a/docs/Upgrading_a_Clearwater_deployment.md
+++ b/docs/Upgrading_a_Clearwater_deployment.md
@@ -62,11 +62,16 @@ Bonos, and one Ellis, you should upgrade them in the following order:
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install.md) run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node in the order described above.
+If you installed your system using the [Manual Install Instructions](Manual_Install.md) run `sudo apt-get update -o` `Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" &&` 
+`sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node in the order described above.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef.md):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client && sudo clearwater-upgrade` on each node in the order described above.
+* Run the following command on each node in the order described above.
+
+`sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o`
+`APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client &&`
+`sudo clearwater-upgrade` on each node in the order described above.

--- a/docs/Upgrading_a_Clearwater_deployment.md
+++ b/docs/Upgrading_a_Clearwater_deployment.md
@@ -21,14 +21,19 @@ uninterrupted service, see "Seamless Upgrade" below.
 
 ### Manual Install
 
-If you installed your system using the [Manual Install Instructions](Manual_Install.md), run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node.
+If you installed your system using the [Manual Install Instructions](Manual_Install.md), run `sudo apt-get update -o` `Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" &&`
+`sudo apt-get install clearwater-infrastructure && sudo clearwater-upgrade` on each node.
 
 ### Chef Install
 
 If you installed your deployment with [chef](Creating_a_deployment_with_Chef.md):
 
 * Follow the instructions to [update the Chef server](https://github.com/Metaswitch/chef#updating-the-chef-server)
-* Run `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client && sudo clearwater-upgrade` on each node.
+* Run the following command on each node.
+
+`sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-"` 
+`-o APT::Get::List-Cleanup="0" && sudo apt-get install clearwater-infrastructure && sudo chef-client &&` 
+`sudo clearwater-upgrade`
 
 ## Seamless Upgrade
 


### PR DESCRIPTION
The commands for upgrading a Clearwater deployment are long and the lines don't break, making it difficult to copy/paste them. This fixes the problem by inserting line breaks.