### PR TITLE
Escape special character in enum

### DIFF
--- a/docs/ENUM.md
+++ b/docs/ENUM.md
@@ -100,7 +100,7 @@ from an example deployment might form a reasonable basis:
             },
             {   "name" : "Clearwater internal numbers dialled with +1 prefix",
                 "prefix" : "+1650555",
-                "regex" : "!^+1(.*$)!sip:\\1@ngv.example.com!"
+                "regex" : "!^\\+1(.*$)!sip:\\1@ngv.example.com!"
             },
             {   "name" : "NANP => SIP trunk",
                 "prefix" : "",

--- a/docs/ENUM.md
+++ b/docs/ENUM.md
@@ -109,6 +109,10 @@ from an example deployment might form a reasonable basis:
         ]
     }
 
+NB: The first part of the regex matches on the entire number and takes out the
+bit inside the bracket, to replace \\\\1 in second expression. Eg. The second last 
+rule will replace `+166655500` with `sip:66655500@ngv.example.com`.
+
 ## Configuring ENUM rules
 
 Normally, the ENUM server would be an existing part of the customer's


### PR DESCRIPTION
Someone encountered a problem with matching the regex and raised it to our mailing list. The regex is missing escape character. I am wondering if a simple explanation like `The first part of the regex matches on the number, and replace \\1 in second expression with what is matched by (.*$)` will help people understand the usage better.